### PR TITLE
Add custom args support for default restart script

### DIFF
--- a/server.go
+++ b/server.go
@@ -273,7 +273,7 @@ func (s *Server) restartScript(typ, who, checksum string) (script string) {
 		`echo "[harp] {\"datetime\": \"$(date)\", \"user\": \"$harp_composer\", \"type\": \"%s\"%s}" | tee -a %s %s >/dev/null`+"\n",
 		typ, checksum, log, s.HistoryLogPath(),
 	)
-	script += fmt.Sprintf("%s nohup %s/bin/%s %s >> %s 2>&1 &\n", envs, s.GoPath, app.Name, args, log)
+	script += fmt.Sprintf("%s nohup %s/bin/%s %s $@ >> %s 2>&1 &\n", envs, s.GoPath, app.Name, args, log)
 	script += fmt.Sprintf("echo $! > %s\n", pid)
 	script += "cd " + s.Home
 	return


### PR DESCRIPTION
I've made small modification for using custom args for default restart.sh directly as app args. For example, it can be really useful with executing app as a cron job.